### PR TITLE
yadm/bootstrap: Fix bug that occurs if USERNAME is not set

### DIFF
--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -65,7 +65,7 @@ apt_get_install_1(){
 }
 
 useradd_user(){
-    if [ -z "${USERNAME}" ]; then
+    if [ -z "${USERNAME-}" ]; then
         return 0
     fi
     USER_UID=${USER_UID:-"automatic"}


### PR DESCRIPTION
This was originally designed and tested in devcontainer,however when used in a typical environment this username is not set. If the username is not set then no user should be created.